### PR TITLE
Save refresh token after sync

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,8 +9,9 @@ import (
 )
 
 type Client struct {
-	Client   http.Client
-	Division int
+	Client      http.Client
+	Division    int
+	TokenSource tokenSource
 }
 
 var ErrNoDivision = errors.New("exactonline/api: Client has no Division, use Client.GetDefaultDivision first")
@@ -24,6 +25,7 @@ func (c Config) NewClient(tok oauth2.Token) *Client {
 	_ = ts
 	b, _ := url.Parse(c.BaseURL)
 	return &Client{
+		TokenSource: ts,
 		Client: http.Client{
 			Transport: &oauth2.Transport{
 				Base:   &Transport{BaseURL: b},

--- a/cmd/koppeling/main.go
+++ b/cmd/koppeling/main.go
@@ -176,7 +176,7 @@ func (app *Application) runTimedSync() {
 			}
 
 			for _, cred := range creds {
-				handlers.SyncRecras(&cred, entry.WithField("recras_hostname", cred.RecrasHostname))
+				handlers.SyncRecras(&cred, entry.WithField("recras_hostname", cred.RecrasHostname), app.db)
 			}
 		}
 


### PR DESCRIPTION
Exact Online is updating how refresh tokens work. See: https://support.exactonline.com/community/s/knowledge-base#All-All-DNO-Content-oauth-eol-oauth-dev-step4

> You now have a new access token that is valid for 10 minutes, and a new refresh token. You can use your new refresh token to receive a new access token. Your old refresh token is no longer valid.